### PR TITLE
Fixes simultaneously changing range values outside current range resu…

### DIFF
--- a/ionic-range-slider.js
+++ b/ionic-range-slider.js
@@ -126,17 +126,29 @@ angular.module("ion.rangeslider").directive("ionRangeSlider",
                 watchers.push($scope.$watch('from', function(value) {
                     var slider = $element.data("ionRangeSlider");
                     if (slider.old_from !== value) {
-                        slider.update({
-                            from: value
-                        });
+                        
+                        if(value <= slider.old_to) {
+                            slider.update({
+                                from: value
+                            });
+                        } else {
+                            slider.update({from: value, to: value});
+                        }
+                        
                     }
                 }));
                 watchers.push($scope.$watch('to', function(value) {
                     var slider = $element.data("ionRangeSlider");
                     if (slider.old_to !== value) {
-                        slider.update({
-                            to: value
-                        });
+                        
+                        if(value >= slider.old_from) {
+                            slider.update({
+                                to: value
+                            });
+                        } else {
+                            slider.update({from: value, to: value});
+                        }
+                        
                     }
                 }));
                 watchers.push($scope.$watch('disable', function(value) {


### PR DESCRIPTION
…lts in only one value being changed

Simultaneously changing range values outside current range results in only one value being changed.

Given the current range is [20, 30]:
When I update the range using:
`$scope.model.age.min = 40; $scope.model.age.max = 50;`
(similar to the example in the README)
This results in a new range of [30, 50].

The reason for this is that the min value is changed first but can not become higher than the old max value.